### PR TITLE
Adding completion of refs

### DIFF
--- a/src/PSGitCompletions/Git.cs
+++ b/src/PSGitCompletions/Git.cs
@@ -64,10 +64,10 @@ namespace PowerCode
 
                 var objectType = parts[1] switch
                 {
-                    "blob" => GitRef.ObjectType.Blob,
-                    "tree" => GitRef.ObjectType.Tree,
-                    "commit" => GitRef.ObjectType.Commit,
-                    "tag" => GitRef.ObjectType.Tag,
+                    "blob" => GitObjectType.Blob,
+                    "tree" => GitObjectType.Tree,
+                    "commit" => GitObjectType.Commit,
+                    "tag" => GitObjectType.Tag,
                     var invalidType => throw new BadOutputException($"Git ref has an invalid object type '{invalidType}'")
                 };
 

--- a/src/PSGitCompletions/GitCompleter.cs
+++ b/src/PSGitCompletions/GitCompleter.cs
@@ -217,7 +217,7 @@ namespace PowerCode
 
         private static IList<CompletionResult> CompleteCheckout(CompleteCommandParameters completeCommandParameters) {
             var wordToComplete = completeCommandParameters.WordToComplete;
-            return completeCommandParameters.AfterDoubleDash ? CompleteModifiedFiles(wordToComplete) : CompleteBranchesAndLog(wordToComplete);
+            return completeCommandParameters.AfterDoubleDash ? CompleteModifiedFiles(wordToComplete) : CompleteRefsAndLog(wordToComplete);
         }
 
         private static IList<CompletionResult> CompleteModifiedFiles(string wordToComplete) {
@@ -257,12 +257,10 @@ namespace PowerCode
                 .ToList();
         }
 
-        private static IList<CompletionResult> CompleteBranchesAndLog(string wordToComplete) {
-            var res = Git.Heads(match: wordToComplete)
-                .Select(c => new CompletionResult(completionText: c, listItemText: c, resultType: CompletionResultType.ParameterValue, toolTip: c))
-                .ToList();
-            res.AddRange(CompleteLog(wordToComplete));
-            return res;
+        private static IList<CompletionResult> CompleteRefsAndLog(string wordToComplete)
+        {
+            return CompleteRefs(wordToComplete)
+                .Concat(CompleteLog(wordToComplete)).ToList();
         }
 
         private static List<CompletionResult> GitOptionsToCompletionResults(GitCommandOption[] gitCommandOptions, string wordToComplete)
@@ -282,17 +280,13 @@ namespace PowerCode
             commands.Sort((result, completionResult) => string.CompareOrdinal(result.CompletionText, completionResult.CompletionText));
             return commands;
         }
-    }
 
-    public struct GitRef
-    {
-        public string Commit { get; }
-        public string Name { get; }
-
-        public GitRef(string commit, string name)
+        private static IList<CompletionResult> CompleteRefs(string wordToComplete)
         {
-            Commit = commit;
-            Name = name;
+            return Git.Refs(wordToComplete)
+                .Select(r => new CompletionResult(r.Name, r.Name,
+                    CompletionResultType.ParameterValue, r.Subject))
+                .ToList();
         }
     }
 }

--- a/src/PSGitCompletions/GitRef.cs
+++ b/src/PSGitCompletions/GitRef.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace PowerCode
+{
+    public struct GitRef
+    {
+        public enum ObjectType
+        {
+            Blob,
+            Tree,
+            Commit,
+            Tag
+        }
+
+        public string Commit { get; }
+        public ObjectType Type { get; }
+        public string Name { get; }
+        public string Subject { get; }
+
+        public GitRef(string commit, ObjectType type, string name, string subject)
+        {
+            Commit = commit;
+            Type = type;
+            Name = name;
+            Subject = subject;
+        }
+    }
+}

--- a/src/PSGitCompletions/GitRef.cs
+++ b/src/PSGitCompletions/GitRef.cs
@@ -4,25 +4,26 @@ namespace PowerCode
 {
     public struct GitRef
     {
-        public enum ObjectType
-        {
-            Blob,
-            Tree,
-            Commit,
-            Tag
-        }
 
         public string Commit { get; }
-        public ObjectType Type { get; }
+        public GitObjectType ObjectType { get; }
         public string Name { get; }
         public string Subject { get; }
 
-        public GitRef(string commit, ObjectType type, string name, string subject)
+        public GitRef(string commit, GitObjectType objectType, string name, string subject)
         {
             Commit = commit;
-            Type = type;
+            ObjectType = objectType;
             Name = name;
             Subject = subject;
         }
+    }
+
+    public enum GitObjectType
+    {
+        Blob,
+        Tree,
+        Commit,
+        Tag
     }
 }

--- a/src/PSGitCompletions/GitRemote.cs
+++ b/src/PSGitCompletions/GitRemote.cs
@@ -1,0 +1,14 @@
+﻿namespace PowerCode
+{
+    public struct GitRemote
+    {
+        public string Commit { get; }
+        public string Name { get; }
+
+        public GitRemote(string commit, string name)
+        {
+            Commit = commit;
+            Name = name;
+        }
+    }
+}

--- a/src/PSGitCompletions/GitRemote.cs
+++ b/src/PSGitCompletions/GitRemote.cs
@@ -1,6 +1,8 @@
-﻿namespace PowerCode
+﻿using System;
+
+namespace PowerCode
 {
-    public struct GitRemote
+    public class GitRemote : IComparable<GitRemote>, IEquatable<GitRemote>, IComparable
     {
         public string Commit { get; }
         public string Name { get; }
@@ -9,6 +11,31 @@
         {
             Commit = commit;
             Name = name;
+        }
+
+        public int CompareTo(GitRemote? other)
+        {
+            if (ReferenceEquals(this, other))
+                return 0;
+            return other is null ? 1 : string.Compare(Commit, other.Commit, StringComparison.Ordinal);
+        }
+
+        public bool Equals(GitRemote? other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return Commit == other.Commit;
+        }
+
+        public int CompareTo(object? obj)
+        {
+            if (ReferenceEquals(this, obj))
+                return 0;
+            if (obj is null)
+                return 1;
+            return obj is GitRemote other ? CompareTo(other) : throw new ArgumentException($"Object must be of type {nameof(GitRemote)}");
         }
     }
 }

--- a/test/PSGitCompletionsTests/FakeGit.cs
+++ b/test/PSGitCompletionsTests/FakeGit.cs
@@ -134,6 +134,26 @@ namespace GitCompletionTests {
             "upstream	https://github.com/powershell/PowerShell (push)"
         };
 
+        private static readonly string[] GetGitRefs = {
+             "afcff36\0commit\0ext-method\0adding resharper settings to gitignore",
+             "2a9ace8\0commit\0foreach-member-typeinference\0Adding tests and fixing issues",
+             "8e2a3ad\0commit\0master\0Moving CurrentTypeDefinitionAst to TypeInferenceContext",
+             "2117538\0commit\0native-arg-hyphen\0Typo in Format-Hex (#3539)",
+             "2f74cd0\0commit\0overload-err\0Removing the Ast.GetInferredType virtual methods from all ASTs",
+             "48e07bf\0commit\0process-completion\0Use /bin/bash, fixes #3525",
+             "6f02a0a\0commit\0psmethod-func\0Fix crash at startup when env:HOME not set (#3437)",
+             "51253d2\0commit\0typeinference-visitor\0Adding public ValidRootDrives property to ValidateDrive (#3510)",
+             "06020f3\0commit\0updatehelp-progress\0Add sudo for adding cert for OpenSUSE (#3524)",
+             "2851f7e\0commit\0vs2017-build\0Enabling TypeInference use of runtime SafeExprEval for completion",
+             "47ec6b2\0commit\0SD/688741\0Accept `-i` for an interactive shell (#3558)",
+             "4ad4b19\0commit\0SD/692351\0Use IntPtr(-1) for INVALID_HANDLE_VALUE instead of IntPtr.Zero (#3544)",
+             "acec58c\0commit\0SD/693793\0Convert tab indentations to spaces in *.cs files (#3551)",
+             "f0c0176\0tag\0v0.1.0\0adding resharper settings to gitignore",
+             "3516872\0tag\0v0.2.0\0Moving CurrentTypeDefinitionAst to TypeInferenceContext",
+             "8d4db01\0tag\0v6.0.0-alpha.18\0Typo in Format-Hex (#3539)",
+             "68bcd4b\0tag\0v6.0.0-alpha.7\0Enabling TypeInference use of runtime SafeExprEval for completion",
+        };
+
         public static  string[] Execute(string command) {
             return command switch {
                 "git for-each-ref '--format=%(refname:strip=2)' 'refs/heads/*' 'refs/heads/*/**'" => GitHeads,
@@ -147,6 +167,7 @@ namespace GitCompletionTests {
                 "git ls-files -- " => GetGitLsFiles,
                 "git config --get-regex ^alias\\." => GetGitAliases,
                 "git config --get-regex ^alias\\.ad" => Array.Empty<string>(),
+                "git for-each-ref '--format=%(objectname:short=7)%00%(objecttype)%00%(refname:lstrip=2)%00%(subject)' 'refs/*/*'" => GetGitRefs,
                 _ => throw new ArgumentException(command)
             };
         }

--- a/test/PSGitCompletionsTests/GitCompletionTests.cs
+++ b/test/PSGitCompletionsTests/GitCompletionTests.cs
@@ -91,7 +91,7 @@ namespace GitCompletionTests
 
         [DataTestMethod]
         [DataRow("git checkout -- ", "src/PSGitCompletions/Git.cs", 7)]
-        [DataRow("git checkout ", "ext-method", 30)]
+        [DataRow("git checkout ", "ext-method", 37)]
         public void CanCompleteCheckoutFiles(string command, string firstResult, int resultCount)
         {
             using var scope = FakeGit.GetScope();


### PR DESCRIPTION
This change adds support for completion of refs when completing the git checkout command. It uses the information about each ref to provide completion of the ref with it's name and and subject.

Also updated the checkout test to expect heads, tags and commits to be completed.